### PR TITLE
Bug fix: Made WiFiSecureClient member var a pointer

### DIFF
--- a/src/lib/PubSubClient/PubSubClient.cpp
+++ b/src/lib/PubSubClient/PubSubClient.cpp
@@ -122,7 +122,9 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
         int result = 0;
 
         if (domain != NULL) {
-            result = _client->connect(this->domain, this->port);  // Experiment with adding timeout here
+            Serial.print("PUBSUB: Attempting socket connection to ");
+            Serial.println(this->domain);
+            result = _client->connect(this->domain, this->port);
         } else {
             result = _client->connect(this->ip, this->port);
         }

--- a/src/networking/SensorMQTT.cpp
+++ b/src/networking/SensorMQTT.cpp
@@ -19,9 +19,10 @@ bool SensorMQTT::initializeMQTT(mqttMsgRecCallback callback) {
     BearSSL::X509List cert(caCert);
     BearSSL::X509List client_crt(clientCert);
     BearSSL::PrivateKey key(privateKey);
-    wifiClient.setTrustAnchors(&cert);
-    wifiClient.setClientRSACert(&client_crt, &key);
-    setClient(wifiClient);
+    this->wifiClient = new WiFiClientSecure();
+    this->wifiClient->setTrustAnchors(&cert);
+    this->wifiClient->setClientRSACert(&client_crt, &key);
+    setClient(*wifiClient);
 
     // Set indicator LED (solid colour because of blocking functions in external lib)
     GDoorIO::getInstance().networkLEDSetCyan();
@@ -42,9 +43,7 @@ bool SensorMQTT::initializeMQTT(mqttMsgRecCallback callback) {
     }
 }
 
-bool SensorMQTT::connectDeviceGateway() {
-    Serial.print("MQTT: Attempting to connect to AWS IoT Cloud -> ");
-    Serial.println(AWS_IOT_DEVICE_GATEWAY);    
+bool SensorMQTT::connectDeviceGateway() {  
     bool success = this->connect(SENSOR_UID);
 
     if (success) {
@@ -66,9 +65,9 @@ bool SensorMQTT::reconnectClientSync() {
   BearSSL::X509List cert(caCert);
   BearSSL::X509List client_crt(clientCert);
   BearSSL::PrivateKey key(privateKey);
-  wifiClient.setTrustAnchors(&cert);
-  wifiClient.setClientRSACert(&client_crt, &key);
-  setClient(wifiClient);
+  this->wifiClient->setTrustAnchors(&cert);
+  this->wifiClient->setClientRSACert(&client_crt, &key);
+  setClient(*wifiClient); // Should be able to remove
 
   // Not explicitly required - but to be sure after wifi dropout
   this->ntpConnect();

--- a/src/networking/SensorMQTT.hpp
+++ b/src/networking/SensorMQTT.hpp
@@ -46,7 +46,7 @@ class SensorMQTT: public PubSubClient{
         void deserializeStdPayload(char* payload, std::string *sensorUID); 
 
     private:
-        WiFiClientSecure wifiClient; // Needs to be persisted
+        WiFiClientSecure *wifiClient; // Needs to be persisted
         // void publishMessage(char* topic, const JsonObject& payload); [Re-implement when possible]
         void generateTopic(char* topic,const char* target, const char* targetUID, const char* msgCategory, const char* descriptor);
         void pubSubError(int8_t MQTTErr);


### PR DESCRIPTION
- Allows instantiation of the WiFiSecureClient object in the initialisation method.
- Means the object gets clean creation